### PR TITLE
fix(ci): drop --ignore-scripts option

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -33,7 +33,7 @@ jobs:
             ${{ env.cache-version }}-${{ runner.os }}-
       - name: Prepare
         run: |
-          npm ci --ignore-scripts
+          npm ci
           npm run build
           npm test
       - name: Publish and Release


### PR DESCRIPTION
## このPullRequestが解決する内容
npm install 時に `--ignore-scripts` を指定すると node-canvas の pre-build に失敗してしまうため `--ignore-scripts` を削除します。
こちらも自明のためセルフマージいたします。