### PR TITLE
Fix renovate error

### DIFF
--- a/src/GameClient.ts
+++ b/src/GameClient.ts
@@ -1,12 +1,12 @@
 import { RunnerV1, RunnerV1Game, RunnerV2, RunnerV2Game, RunnerV3, RunnerV3Game } from "@akashic/headless-driver";
-import { ResourceFactory as ResourceFactoryV1 } from "@akashic/headless-driver-runner-v1/lib/platform/ResourceFactory";
-import { ResourceFactory as ResourceFactoryV2 } from "@akashic/headless-driver-runner-v2/lib/platform/ResourceFactory";
-import { NodeCanvasResourceFactory as ResourceFactoryV3_NodeCanvas } from "@akashic/headless-driver-runner-v3/lib/platform/NodeCanvasResourceFactory";
-import { NullResourceFactory as ResourceFactoryV3_Null } from "@akashic/headless-driver-runner-v3/lib/platform/NullResourceFactory";
+import type { RunnerAdvanceConditionFunc, RunnerRenderingMode } from "@akashic/headless-driver";
+import { ResourceFactory as ResourceFactoryV1 } from "@akashic/headless-driver/lib/runner/v1/platform/ResourceFactory";
+import { ResourceFactory as ResourceFactoryV2 } from "@akashic/headless-driver/lib/runner/v2/platform/ResourceFactory";
+import { NodeCanvasResourceFactory as ResourceFactoryV3_NodeCanvas } from "@akashic/headless-driver/lib/runner/v3/platform/NodeCanvasResourceFactory";
+import { NullResourceFactory as ResourceFactoryV3_Null } from "@akashic/headless-driver/lib/runner/v3/platform/NullResourceFactory";
+import type { Canvas } from "canvas";
 import * as uuid from "uuid";
 import type { EngineVersions } from "./types";
-import type { RunnerAdvanceConditionFunc, RunnerRenderingMode } from "@akashic/headless-driver";
-import type { Canvas } from "canvas";
 
 type Runner = RunnerV1 | RunnerV2 | RunnerV3;
 


### PR DESCRIPTION
## 概要

renovate で `headless-driver@2.0.0` 更新に伴うエラー対応
- 参照先が変わったため修正。

renovate の #46 へマージします。

Bump version のPR (ver2.3.0へあげる & CHANGELOG更新)は #46 マージ後に別途出します。