### PR TITLE
Bump version 3.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # CHANGELOG
 
+## 3.0.1
+* headless-driver@2.1.1 に追従
+
 ## 3.0.0
 * headless-driver@2.0.0 に追従
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@akashic/headless-akashic",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@akashic/headless-akashic",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "license": "MIT",
       "dependencies": {
         "@akashic/headless-driver": "^2.1.1",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@akashic/headless-akashic",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "description": "A headless module for launching contents with the Akashic Engine",
   "main": "lib/index.js",
   "scripts": {


### PR DESCRIPTION
## 概要
headless-drive@2.1.1 へ更新のため、version を 3.0.1 へあげます。
セルフマージとします。