### PR TITLE
chore: add devEngines.packageManager to package.json

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
       max-parallel: 4
       matrix:
         os: [ubuntu-latest, windows-latest]
-        node: [22.x, 24.x]
+        node: [24.x]
     steps:
       - name: Checkout code
         uses: actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8 # v6.0.1

--- a/package.json
+++ b/package.json
@@ -87,5 +87,12 @@
   },
   "publishConfig": {
     "@akashic:registry": "https://registry.npmjs.org/"
+  },
+  "devEngines": {
+    "packageManager": {
+      "name": "npm",
+      "version": ">=11.11.0",
+      "onFail": "error"
+    }
   }
 }


### PR DESCRIPTION
This PR adds `devEngines.packageManager` to package.json to enforce npm version.